### PR TITLE
Pass onPanResponderRelease params to pressDragRelease

### DIFF
--- a/Draggable.js
+++ b/Draggable.js
@@ -76,7 +76,7 @@ export default class Draggable extends Component {
 			}]),
 			onPanResponderRelease: (e, gestureState) => {
 				if(pressDragRelease)
-					pressDragRelease();
+					pressDragRelease(e, gestureState);
 				if(this.reverse == false)
 					this.state.pan.flattenOffset();
 				else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-draggable",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "draggable",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Fixes #6 partially and https://stackoverflow.com/questions/47463919/react-native-passing-component-object-property-to-onpress-function