### PR TITLE
Added manual reverse method

### DIFF
--- a/Draggable.js
+++ b/Draggable.js
@@ -79,13 +79,12 @@ export default class Draggable extends Component {
 					pressDragRelease(e, gestureState);
 				if(this.reverse == false)
 					this.state.pan.flattenOffset();
-				else {
-					this.reverse();
-				}
+				else 
+					this.reversePosition();
 			} 
 		});
 	}
-	_positionCss = (size,x,y)=>{
+	_positionCss = (size,x,y) =>{
 		let Window = Dimensions.get('window');
 		return {
 			zIndex:999,
@@ -95,7 +94,7 @@ export default class Draggable extends Component {
 
 		};
 	}
-	_dragItemCss = (size,color,shape)=>{
+	_dragItemCss = (size,color,shape) =>{
 		if(shape == 'circle') {
 			return{
 				backgroundColor: color,
@@ -117,7 +116,7 @@ export default class Draggable extends Component {
 			};
 		}
 	}
-	_dragItemTextCss = (size)=>{
+	_dragItemTextCss = (size) =>{
 		return {
 			marginTop: size-10,
 			marginLeft: 5,
@@ -136,7 +135,7 @@ export default class Draggable extends Component {
 
 	}
 	
-	reverse = () => {
+	reversePosition = () =>{
 		Animated.spring(            
 			this.state.pan,         
 			{toValue:{x:0,y:0}}     

--- a/Draggable.js
+++ b/Draggable.js
@@ -80,10 +80,7 @@ export default class Draggable extends Component {
 				if(this.reverse == false)
 					this.state.pan.flattenOffset();
 				else {
-					Animated.spring(            
-						this.state.pan,         
-						{toValue:{x:0,y:0}}     
-					).start();
+					this.reverse();
 				}
 			} 
 		});
@@ -137,6 +134,13 @@ export default class Draggable extends Component {
 			return (<Text style={this._dragItemTextCss(this.renderSize)}>{this.renderText}</Text>);
 		}
 
+	}
+	
+	reverse = () => {
+		Animated.spring(            
+			this.state.pan,         
+			{toValue:{x:0,y:0}}     
+		).start();
 	}
 
 	render() {


### PR DESCRIPTION
Can be used to manually reset (reverse) any Draggable object assigned a React ref when props.reverse is false

Resolves issue #11 


Example use:

```
someFunction = () => {
    // You can call this whenever you want to reset the associated ref to its start position
    this.exampleRef.reverse();
}

render() {
    <Draggable
        ref={(draggable) => {this.exampleRef = draggable}}
        renderShape='image'
        imageSource={Images.example}
        renderSize={50}
        reverse={false}
        offsetX={10} offsetY={10}
        pressDragRelease={()=>console.log('press drag release')}
        longPressDrag={()=>console.log('long press')}
        pressDrag={()=>console.log('press drag')}
        pressInDrag={()=>console.log('in press')}
        pressOutDrag={()=>console.log('out press')}
    />
}
```