### PR TITLE
Remove invalid typing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -36,21 +36,4 @@ export interface IDraggableProps {
     maxY?: number;
 }
 declare function Draggable(props: IDraggableProps): JSX.Element;
-Draggable.defaultProps = {
-    renderText: '＋',
-    renderSize: 36,
-    shouldReverse: false,
-    disabled: false,
-    debug: false,
-    onDrag: () => {},
-    onShortPressRelease: () => {},
-    onDragRelease: () => {},
-    onLongPress: () => {},
-    onPressIn: () => {},
-    onPressOut: () => {},
-    onRelease: () => {},
-    x: 0,
-    y: 0,
-    z: 1,
-}
 export default Draggable;


### PR DESCRIPTION
This resolves issue #73 by removing invalid type code from the `index.d.ts` declaration file.

The code removed is an assignment to `defaultProps` which contains number values, string values, booleans, and empty error functions. The assignment and empty error functions are not valid typings so they throw compilation errors.

The code isn't necessary since the props types are defined with `IDraggableProps`.