### PR TITLE
Added Prop `zoom`, allowing constency on dragging on zoomed views.

### DIFF
--- a/Draggable.tsx
+++ b/Draggable.tsx
@@ -54,7 +54,8 @@ interface IProps {
     minY?: number;
     maxX?: number;
     maxY?: number;
-  };
+    zoom?: number;
+};
 
 export default function Draggable(props: IProps) {
   const {
@@ -83,6 +84,7 @@ export default function Draggable(props: IProps) {
     minY,
     maxX,
     maxY,
+    zoom
   } = props;
 
   // The Animated object housing our xy value so that we can spring back
@@ -155,12 +157,12 @@ export default function Draggable(props: IProps) {
       const {top, right, left, bottom} = startBounds.current;
       const far = 999999999;
       const changeX = clamp(
-        dx,
+        dx / zoom,
         Number.isFinite(minX) ? minX - left : -far,
         Number.isFinite(maxX) ? maxX - right : far,
       );
       const changeY = clamp(
-        dy,
+        dy / zoom,
         Number.isFinite(minY) ? minY - top : -far,
         Number.isFinite(maxY) ? maxY - bottom : far,
       );
@@ -333,6 +335,7 @@ Draggable.defaultProps = {
   x: 0,
   y: 0,
   z: 1,
+  zoom: 1
 };
 
 const styles = StyleSheet.create({

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ return (
 | minY | number |{0}| --- | min Y value for top edge of component |
 | maxX | number |{0}| --- | max X value for right edge of component |
 | maxY | number |{0}| --- | max Y value for bottom edge of component |
+| zoom | number |{0.7}| 1 | zoom factor, used for properly animate/accelerate a zoomed in/out draggable view |
 
 ## Events
 | Event | Type | Arguments| Description |

--- a/index.d.ts
+++ b/index.d.ts
@@ -34,6 +34,7 @@ export interface IDraggableProps {
     minY?: number;
     maxX?: number;
     maxY?: number;
+    zoom?: number;
 }
 declare function Draggable(props: IDraggableProps): JSX.Element;
 Draggable.defaultProps = {
@@ -52,5 +53,6 @@ Draggable.defaultProps = {
     x: 0,
     y: 0,
     z: 1,
+    zoom: 1
 }
 export default Draggable;


### PR DESCRIPTION
Recently I had a use case where the user needed to drag items on a zoomed-out view and keep the synectics consistent.

As it is right now, if you try to drag an element on a zoomed-out view, the movement won't match the velocity of the element being animated, since it takes into consideration just dy/dx which won't be affected.

This tiny fix adds `zoom` as a prop, with so, it will be used during onDrag operations and keeping the animation smooth.