### PR TITLE
Separate export calls from definition logic

### DIFF
--- a/Draggable.js
+++ b/Draggable.js
@@ -20,7 +20,7 @@ function clamp(number, min, max) {
   return Math.max(min, Math.min(number, max));
 }
 
-export default function Draggable(props) {
+function Draggable(props) {
   const {
     renderText,
     isCircle,
@@ -345,3 +345,5 @@ const styles = StyleSheet.create({
     borderWidth: 4,
   },
 });
+
+export default Draggable;

--- a/Draggable.tsx
+++ b/Draggable.tsx
@@ -56,7 +56,7 @@ interface IProps {
     maxY?: number;
   };
 
-export default function Draggable(props: IProps) {
+function Draggable(props: IProps) {
   const {
     renderText,
     isCircle,
@@ -344,3 +344,5 @@ const styles = StyleSheet.create({
     borderWidth: 4,
   },
 });
+
+export default Draggable;


### PR DESCRIPTION
In accordance with [this issue](https://github.com/storybookjs/storybook/issues/11419#issuecomment-658969643), if using this in Storybook (particularly with TypeScript) `export` calls need to be separated from the definition of the element to be exported. If not, Storybook can't properly parse the implementation. With this fix in-place, react-native-web and Storybook are capable of utilising this component.